### PR TITLE
Added the structure of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # process-genie
 Cross-platform node process memory manipulation library 
+
+## Basic Usage
+
+```js
+const genie = require('process-genie');
+
+const proc = genie.attach(1337);
+```
+
+## Read Memory
+
+```js
+const someBytesFromTheProcess = proc.readMemory(0xDEADBEEF, 20);
+console.log(new Uint8Array(someBytesFromTheProcess));
+```
+
+## Write Memory
+
+```js
+proc.writeMemory(0xDEADCODE, new Uint8Array([0xEB, 0xFE]));
+```
+
+## List Mapped Memory Regions
+
+```js
+for (const region of proc.iterateMemoryRegions()) {
+    console.log(region.address, region.size, region.protection);
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,33 @@
+function getNativeProcessClass() {
+    const currentPlatform = process.platform;
+    const nativeProcessModuleName = `./process-${currentPlatform}`;
+
+    try {
+        require.resolve(nativeProcessModuleName);
+    } catch (_) {
+        return null;
+    }
+
+    return require(nativeProcessModuleName);
+}
+
+function assertNativeProcessClassSet() {
+    if (module.exports.Process === null) {
+        throw new Error('Unsupported platform. You can set the `Process` property manually or use a specific process class directly.');
+    }
+}
+
+module.exports.Process = getNativeProcessClass();
+
+module.exports.attach = function(pid) {
+    assertNativeProcessClassSet();
+
+    const proc = new module.exports.Process(pid);
+    proc.attach();
+    return proc;
+};
+
+// TODO:
+// module.exports.iterateOpenProcesses = function*() {
+//    ...
+// };

--- a/lib/process-base.js
+++ b/lib/process-base.js
@@ -1,0 +1,29 @@
+module.exports = class ProcessBase {
+    constructor(pid) {
+        if (this.constructor === ProcessBase) {
+            throw new Error('Cannot instantiate abstract class');
+        }
+
+        this.pid = pid;
+    }
+
+    attach() {
+        throw new Error('Abstract method cannot be called');
+    }
+
+    detach() {
+        throw new Error('Abstract method cannot be called');
+    }
+
+    /* generator */ iterateMemoryRegions() {
+        throw new Error('Abstract method cannot be called');
+    }
+
+    readMemory(address, size) {
+        throw new Error('Abstract method cannot be called');
+    }
+
+    writeMemory(address, buffer) {
+        throw new Error('Abstract method cannot be called');
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,81 @@
+{
+  "name": "process-genie",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "debug": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "ffi-napi": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-2.4.3.tgz",
+      "integrity": "sha512-Lut2d5MvblJ9jw6g06znz0DjSIictZgBX61e7RHBEMX3FWjU5czCuUviPsgHxvjqIlEqm5wWQ5AIUq/G7Agzhg==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "debug": "^3.1.0",
+        "get-uv-event-loop-napi-h": "^1.0.2",
+        "node-addon-api": "^1.1.0",
+        "ref-napi": "^1.4.0",
+        "ref-struct-di": "^1.1.0"
+      }
+    },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.1.tgz",
+      "integrity": "sha512-QvP1+tCDjgTiu+akjdEYd8eK8MFYy6nRCRNjfiCeQB9RJEHQZpN+WE+CVqPRNqjIVMwSqd0WiD008B+b7iIdaA=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.2.tgz",
+      "integrity": "sha512-yhU1qY1Q9CjIVyWSOeGAKrpGP03FOa4YmOJ0cdsE9WMc2HllFsYRtq2zdFdQqqYuGCkrYN8Y9olK/aJYrlXoMA==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "node-addon-api": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.4.0.tgz",
+      "integrity": "sha512-agquHPHnxYGox7Rjz2+TZQeOiH8IVbNFSTyTPA+peMUAP6klgrBH5dcwHsNNChQh7l/dtF0JNmZPbCqd5OXOIQ=="
+    },
+    "ref-napi": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.4.0.tgz",
+      "integrity": "sha512-wPSvH8QHPEZCIPNSUmcLvxKIf4o04W3tYvhsXhoHMH23qcco+62OO6vUtbZEyUXGf+VsfZMNtwYrSC/RcSjX8Q==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "debug": "^3.1.0",
+        "node-addon-api": "https://github.com/nodejs/node-addon-api/archive/82656bb.tar.gz"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "https://github.com/nodejs/node-addon-api/archive/82656bb.tar.gz",
+          "integrity": "sha512-hVXYx8KHOnSva6EH010YqII0JaVW6+UDC7OOZE1+DN0Evu4jL5KEf9ZFCwjRPFN0y/biYbMJKOCqukYpb5DIzw=="
+        }
+      }
+    },
+    "ref-struct-di": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.0.tgz",
+      "integrity": "sha512-gghZITj/iQwdwFDduZ6T8kL2B2ogInlOz7AOB0ggFoEc7akAKMcDrbzh3OIPk13Kxy8U2bHPvN6nejcBh4jN7A==",
+      "requires": {
+        "debug": "^3.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "process-genie",
+  "version": "1.0.0",
+  "description": "Cross-platform node process memory manipulation library",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Purinet/process-genie.git"
+  },
+  "keywords": [
+    "process",
+    "read",
+    "write",
+    "memory",
+    "regions",
+    "cross-platform"
+  ],
+  "author": "Purinet",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Purinet/process-genie/issues"
+  },
+  "homepage": "https://github.com/Purinet/process-genie#readme"
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/Purinet/process-genie/issues"
   },
-  "homepage": "https://github.com/Purinet/process-genie#readme"
+  "homepage": "https://github.com/Purinet/process-genie#readme",
+  "dependencies": {
+    "ffi-napi": "^2.4.3"
+  }
 }


### PR DESCRIPTION
- `npm init`
- abstract `BaseProcess` class
- requiring the process class that matches the current platform were on and setting `exports.Process`
- helper `exports.attach(pid)` function
- documented basic usage in readme

Template for a process class:

```js
const ffi = require('ffi-napi');
const ProcessBase = require('./process-base');

module.exports = class ProcessWin32 extends ProcessBase {
    attach() {
        // TODO
    }

    // ...
};
```